### PR TITLE
Add unit tests for transactions and importer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
   <version>1.0</version>
   <build>
     <sourceDirectory>src/main</sourceDirectory>
+    <testSourceDirectory>src/test/java</testSourceDirectory>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -16,6 +17,11 @@
           <source>8</source>
           <target>8</target>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M5</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -72,6 +78,25 @@
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
       <version>4.3.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.7.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.7.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.7.2</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/com/company/jledger/model/Transaction.java
+++ b/src/main/com/company/jledger/model/Transaction.java
@@ -1,5 +1,6 @@
 package com.company.jledger.model;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
@@ -33,7 +34,7 @@ public class Transaction {
       log.error("From and to account cannot be the same");
       return false;
     }
-    if (fromAmount.getBigDecimal().add(toAmount.getBigDecimal()).intValue() > 0) {
+    if (fromAmount.getBigDecimal().add(toAmount.getBigDecimal()).compareTo(BigDecimal.ZERO) != 0) {
       log.error("From and to amount must be balanced");
       return false;
     }

--- a/src/test/java/com/company/jledger/model/TransactionTest.java
+++ b/src/test/java/com/company/jledger/model/TransactionTest.java
@@ -1,0 +1,79 @@
+package com.company.jledger.model;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class TransactionTest {
+
+  private static final Currency DEFAULT_CURRENCY = new Currency("USD");
+
+  @Test
+  void transactionWithIdenticalAccountsIsInvalid() {
+    Account account = new Account("Assets:Cash");
+    Transaction transaction = Transaction.builder()
+        .date(LocalDate.now())
+        .description("Transfer")
+        .fromAccount(account)
+        .toAccount(account)
+        .fromAmount(amount("10"))
+        .toAmount(amount("-10"))
+        .build();
+
+    assertFalse(transaction.isValid());
+  }
+
+  @Test
+  void transactionWithBalancedAmountsIsValid() {
+    Transaction transaction = Transaction.builder()
+        .date(LocalDate.now())
+        .description("Deposit")
+        .fromAccount(new Account("Income:Salary"))
+        .toAccount(new Account("Assets:Bank"))
+        .fromAmount(amount("100"))
+        .toAmount(amount("-100"))
+        .build();
+
+    assertTrue(transaction.isValid());
+  }
+
+  @Test
+  void transactionWithFractionalImbalanceIsInvalid() {
+    Transaction transaction = Transaction.builder()
+        .date(LocalDate.now())
+        .description("Adjustment")
+        .fromAccount(new Account("Assets:Cash"))
+        .toAccount(new Account("Expenses:Misc"))
+        .fromAmount(amount("100"))
+        .toAmount(amount("-100.50"))
+        .build();
+
+    assertFalse(transaction.isValid());
+  }
+
+  @Test
+  void getRowThrowsWhenLabelDoesNotMatchEitherAccount() {
+    Transaction transaction = Transaction.builder()
+        .date(LocalDate.of(2020, 1, 1))
+        .description("Deposit")
+        .fromAccount(new Account("Income:Salary"))
+        .toAccount(new Account("Assets:Bank"))
+        .fromAmount(amount("100"))
+        .toAmount(amount("-100"))
+        .build();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> transaction.getRow(new Label("Expenses")));
+  }
+
+  private Amount amount(String value) {
+    return Amount.builder()
+        .currency(DEFAULT_CURRENCY)
+        .bigDecimal(new BigDecimal(value))
+        .build();
+  }
+}

--- a/src/test/java/com/company/jledger/service/TransactionImporterTest.java
+++ b/src/test/java/com/company/jledger/service/TransactionImporterTest.java
@@ -1,0 +1,60 @@
+package com.company.jledger.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.company.jledger.model.Currency;
+import com.company.jledger.model.FailConversion;
+import com.company.jledger.model.Transaction;
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TransactionImporterTest {
+
+  private final Currency defaultCurrency = new Currency("USD");
+  private final SimpleDateFormat importFormat = new SimpleDateFormat("dd.MM.yyyy");
+
+  @Test
+  void parsesTransactionWithoutExplicitToAmount() {
+    TransactionImporter importer = new TransactionImporter(defaultCurrency, importFormat);
+
+    List<FailConversion> failures = importer.readTransactions(Collections.singletonList(
+        "01.02.2020,Salary,Income:Salary,1000,Assets:Bank"));
+
+    assertTrue(failures.isEmpty(), () -> "Unexpected failures: " + failures);
+    assertEquals(1, importer.getTransactions().size());
+    Transaction transaction = importer.getTransactions().get(0);
+    assertEquals(LocalDate.of(2020, 2, 1), transaction.getDate());
+    assertEquals(new BigDecimal("-1000"), transaction.getToAmount().getBigDecimal());
+    assertEquals(defaultCurrency, transaction.getToAmount().getCurrency());
+  }
+
+  @Test
+  void parsesTransactionWithExplicitBalancedToAmount() {
+    TransactionImporter importer = new TransactionImporter(defaultCurrency, importFormat);
+
+    List<FailConversion> failures = importer.readTransactions(Collections.singletonList(
+        "05.03.2021,Coffee,Assets:Bank,-5.25,Expenses:Food,5.25"));
+
+    assertTrue(failures.isEmpty(), () -> "Unexpected failures: " + failures);
+    assertEquals(1, importer.getTransactions().size());
+    Transaction transaction = importer.getTransactions().get(0);
+    assertEquals(new BigDecimal("5.25"), transaction.getToAmount().getBigDecimal());
+    assertEquals(new BigDecimal("-5.25"), transaction.getFromAmount().getBigDecimal());
+  }
+
+  @Test
+  void recordsFailureWhenExplicitToAmountIsNotBalanced() {
+    TransactionImporter importer = new TransactionImporter(defaultCurrency, importFormat);
+
+    List<FailConversion> failures = importer.readTransactions(Collections.singletonList(
+        "10.04.2021,Adjustment,Assets:Bank,100,Expenses:Fees,-99.50"));
+
+    assertEquals(1, failures.size());
+    assertTrue(importer.getTransactions().isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary
- add JUnit 5 dependencies and Surefire configuration to enable a test suite
- tighten transaction balance validation so any non-zero imbalance is rejected
- add unit tests covering transaction validation and the importer conversion paths

## Testing
- `mvn test` *(fails: unable to download Maven plugins in offline environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691360eb6e2083338aeb6c174158448d)